### PR TITLE
Fix file_name in GOG Galaxy installer

### DIFF
--- a/Games/gog.yml
+++ b/Games/gog.yml
@@ -22,7 +22,7 @@ Executable:
   
 Steps:
 - action: install_exe
-  file_name: setup_galaxy_2.0.43.71.exe
+  file_name: setup_galaxy_2.0.45.61.exe
   url: https://content-system.gog.com/open_link/download?path=/open/galaxy/client/2.0.45.61/setup_galaxy_2.0.45.61.exe
   file_checksum: 5d2ae5367f72b3a23728bb8732e6df4e
   arguments: /s


### PR DESCRIPTION
I think this should be updated every time the url field changes.

I haven't tested this chance, just saw the discrepancy when I was about to run the installer. How come the installer works with the differing file names? And that begs the question: is this field even necessary?