### PR TITLE
eaclient: Update checksum

### DIFF
--- a/Games/eaclient.yml
+++ b/Games/eaclient.yml
@@ -26,4 +26,4 @@ Steps:
 - action: install_exe
   file_name: EAappInstaller.exe
   url: https://origin-a.akamaihd.net/EA-Desktop-Client-Download/installer-releases/EAappInstaller.exe
-  file_checksum: e4c63ac2e6075c18e16eb973823f11aa
+  file_checksum: ba888df7885b21e5b2c0e00252a75106


### PR DESCRIPTION
Just downloaded it manually since the installer doesn't work.

$ md5sum EAappInstaller.exe
ba888df7885b21e5b2c0e00252a75106  EAappInstaller.exe

Note: The installer UI gives a false positive on downloads with bad checksums if I'm right here. The install step is skipped and I get a checkmark.