### PR TITLE
Update Ubisoft installer checksum

### DIFF
--- a/Games/uplay.yml
+++ b/Games/uplay.yml
@@ -26,7 +26,7 @@ Steps:
 - action: install_exe
   file_name: UbisoftConnectInstaller.exe
   url: https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UbisoftConnectInstaller.exe
-  file_checksum: 921b7fb84dfa059b10afe47aa31bdccc
+  file_checksum: 0aef4ce3f61912d2c238ad250c0c7999
   arguments: /S
   
 - action: update_config


### PR DESCRIPTION
I tried to install the Ubisoft launcher but it failed because the checksum changed. Here is the updated checksum.