### PR TITLE
Origin: add d3dx11 as dependency

### DIFF
--- a/Games/origin.yml
+++ b/Games/origin.yml
@@ -5,6 +5,7 @@ Arch: win64
 
 Dependencies:
 - d3dx9
+- d3dx11
 - riched20
 - allfonts
 - d3dcompiler_43


### PR DESCRIPTION
I am unable to finish installing the Origin client into a gaming bottle without first adding the d3dx11 dependency into the bottle. Without this, I get through the first phase of the Origin installer, but the second phase results in a black window.

Additionally, I think the Origin installer provided by Bottles needs to be updated--the first thing it seems to do is get the more recent version from Origin.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No
