### PR TITLE
Unable to run Ableton Live (11.2_64) from Win64 custom sys-wine-7.0 bottle

### DIFF
--- a/Reviews/abletonlive.md
+++ b/Reviews/abletonlive.md
@@ -4,32 +4,32 @@ Review for the Ableton Live installer.
 Maintainers: @nickberry17
 
 **Is the program properly opened?**  
-Grade: Silver  
-Additional notes: Installer may freeze for a moment or two showing a black screen. Just keep pressing wait, it should eventually work.
+Grade: Broken  
+Additional notes: Using a custom sys-wine-7.0 bottle with only the "Allfonts" dependency enabled I downloaded ableton_live_trial_11.2_64 installer (with 2 data.cab files). The installer completes without error and shows a "Ableton Live is now available in the programs view." However running it from the Programs menu does not work or 
 
 **Is it showing alerts or other warnings?**  
 Grade: Silver  
-Additional notes: n/a
+Additional notes: Only a "Launching 'Ableton Live'" message appears for ~10 seconds then goes away with no error message.
 
 **Does it show graphical glitches?**  
-Grade: Silver  
-Additional notes: n/a
+Grade: Broken
+Additional notes: Program never launches
 
 **Does it require some tweaking in order to work properly? (Out of normal software configuration)**  
-Grade: Platinum  
-Additional notes: n/a
+Grade: Broken
+Additional notes: Program never launches
 
 **Did it crash during tests execution?**  
-Grade: Gold  
+Grade: Silver 
 Additional notes: n/a
 
 **Is it usable?**  
-Grade: Gold  
-Additional notes: n/a
+Grade: Broken
+Additional notes: No
 
 **Final grade? (the lower evaluation from previous questions)**  
-Grade: Silver  
-Additional notes: n/a
+Grade: Broken
+Additional notes: Program never launches
 
 **Additional notes**  
 You need to download your version of Live, extract it, then point the installer to that .exe file.


### PR DESCRIPTION
Fixes #(issue)

## Type of change
- [ ] New installer
- [ ] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [ ] No
