### PR TITLE
Add mono dependency to Epic Games Launcher installer

### DIFF
--- a/Games/epicgamestore.yml
+++ b/Games/epicgamestore.yml
@@ -11,6 +11,7 @@ Dependencies:
 - d3dcompiler_43
 - d3dcompiler_47
 - vcredist2015
+- mono
 
 Parameters:
   dxvk: true


### PR DESCRIPTION
EOS (Epic Online Services) is now required for future updates to Epic Games Launcher, and it has a dependency on .NET 3.5. Mono as the open-source implementation of .NET has been working fine in my tests.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
