### PR TITLE
Update GOG Galaxy 2.0.60.2, improve grade to Gold

### DIFF
--- a/Games/gog.yml
+++ b/Games/gog.yml
@@ -1,6 +1,6 @@
 Name: gog
 Description: The official GOG Galaxy launcher.
-Grade: Silver
+Grade: Gold
 Arch: win64
 
 Dependencies:

--- a/Games/gog.yml
+++ b/Games/gog.yml
@@ -22,7 +22,7 @@ Executable:
   
 Steps:
 - action: install_exe
-  file_name: setup_galaxy_2.0.57.14.exe
-  url: https://content-system.gog.com/open_link/download?path=/open/galaxy/client/2.0.57.14/setup_galaxy_2.0.57.14.exe
-  file_checksum: 4bf3ad1aa0a44418f326814622b9e1d5
+  file_name: setup_galaxy_2.0.60.2.exe
+  url: https://content-system.gog.com/open_link/download?path=/open/galaxy/client/2.0.60.2/setup_galaxy_2.0.60.2.exe
+  file_checksum: 87f5cafeb89af087611af52539a28a7b
   arguments: /s

--- a/Reviews/gog.md
+++ b/Reviews/gog.md
@@ -13,7 +13,7 @@ Additional n/a
 
 **Does it show graphical glitches?**  
 Grade: Gold  
-Additional notes: Lag on launch but works smoothly after login.
+Additional notes: Minor graphical issues, like the screen sometimes not updating until the mouse moves over an interactable element.
 
 **Does it require some tweaking in order to work properly? (Out of normal software configuration)**  
 Grade: Platinum  
@@ -24,11 +24,12 @@ Grade: Platinum
 Additional notes: n/a
 
 **Is it usable?**  
-Grade: Silver  
-Additional notes: GalaxyClientService.exe crashes often, bringing up an alert window and interrupting gameplay. The best way to go about it is to not dismiss the alert, just Alt+Tab back to the game, that way you won't get further interruptions from that alert.
+Grade: Gold  
+Additional notes: Some times installation of games fail. Retrying several times can often work around it.
+Cloud Sync of game saves fails often.
 
 **Final grade? (the lower evaluation from previous questions)**  
-Grade: Silver  
+Grade: Gold  
 Additional notes: n/a
 
 **Additional notes**  

--- a/index.yml
+++ b/index.yml
@@ -51,7 +51,7 @@ gog:
   Arch: win64
   Name: GOG Galaxy
   Description: The official GOG Galaxy launcher.
-  Grade: Silver
+  Grade: Gold
   Category: Games
   Icon: gog.svg
   Event: setup_galaxy_2.*.exe


### PR DESCRIPTION
Update GOG Galaxy 2.0.60.2

This version fixed the major issue of constant crashing, improving grade to Gold. Crashing on Cloud Saving is also fixed, it still fails often, just without a crash now, which is much better.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
