### PR TITLE
Add missing dependency in Estlcam

### DIFF
--- a/Software/estlcam.yml
+++ b/Software/estlcam.yml
@@ -3,6 +3,9 @@ Description: "2D / 3D CAM"
 Grade: Platinum
 Arch: win64
 
+Dependencies:
+- mono
+
 Executable:
   name: Estlcam
   icon: estlcam.png


### PR DESCRIPTION
If mono is not installed in the system the app can't launch (so flatpak for example)

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
