### PR TITLE
Updated Star Citizen installer and added review note.

### DIFF
--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -29,6 +29,37 @@ Steps:
   file_checksum: acdc48032606bcf4e0913e15711b5fc2
 - action: run_script
   script: |
-    echo "Creating StarCitizen/LIVE,PTU folders in !bottle_drive"
-    mkdir -p !bottle_drive"/Program Files/Roberts Space Industries/StarCitizen/LIVE"
-    mkdir -p !bottle_drive"/Program Files/Roberts Space Industries/StarCitizen/PTU"
+    export SC_DEFAULT_GAME_PATH="!bottle_drive/Program Files/Roberts Space Industries/StarCitizen"
+    export SC_FIX_SCRIPT="!bottle_drive/starcitizen_fix.sh"
+    mkdir -p "${SC_DEFAULT_GAME_PATH}/LIVE"
+    mkdir -p "${SC_DEFAULT_GAME_PATH}/PTU"
+    cat << EOF > "${SC_FIX_SCRIPT}"
+    #!/bin/bash
+    # Bottles StarCitizen-installer fixer script"
+    # block EAC module access via DNS inside bottle
+    bash !bottle_drive/starcitizen_eac.sh
+    # add sysctl settings
+    pkexec bash !bottle_drive/starcitizen_sysctl.sh
+    EOF
+- action: run_script
+  script: |
+    export SC_DEFAULT_GAME_PATH="!bottle_drive/Program Files/Roberts Space Industries/StarCitizen"
+    export SC_EAC_SCRIPT="!bottle_drive/starcitizen_eac.sh"
+    cat << EOF > "${SC_EAC_SCRIPT}"
+    #!/bin/bash
+    echo "127.0.0.1 modules-cdn.eac-prod.on.epicgames.com #block EAC access" >> !bottle_drive/windows/system32/drivers/etc/hosts
+    cp "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json.backup"
+    sed -i "s#\"productid\":\(\s*\)\"\(.*\)\"#\"productid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
+    sed -i "s#\"sandboxid\":\(\s*\)\"\(.*\)\"#\"sandboxid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
+    sed -i "s#\"clientid\":\(\s*\)\"\(.*\)\"#\"clientid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
+    sed -i "s#\"deploymentid\":\(\s*\)\"\(.*\)\"#\"deploymentid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
+    EOF
+- action: run_script
+  script: |
+    export SC_SYSCTL_SCRIPT="!bottle_drive/starcitizen_sysctl.sh"
+    cat << EOF >> "${SC_SYSCTL_SCRIPT}"
+    #!/bin/bash
+    echo "#Bottles StarCitizen installer" > /etc/sysctl.d/20-starcitizen.conf
+    echo "vm.max_map_count=16777216" >> /etc/sysctl.d/20-starcitizen.conf
+    /usr/sbin/sysctl -p /etc/sysctl.d/20-starcitizen.conf
+    EOF

--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -27,3 +27,8 @@ Steps:
   arguments: /S
   url: https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.6.5.exe
   file_checksum: acdc48032606bcf4e0913e15711b5fc2
+- action: run_script
+  script: |
+    echo "Creating StarCitizen/LIVE,PTU folders in !bottle_drive"
+    mkdir -p !bottle_drive"/Program Files/Roberts Space Industries/StarCitizen/LIVE"
+    mkdir -p !bottle_drive"/Program Files/Roberts Space Industries/StarCitizen/PTU"

--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -4,8 +4,9 @@ Grade: Bronze
 Arch: win64
 
 Dependencies:
-- allfonts
+- arial32
 - vcredist2019
+- mono
 
 Parameters:
   dxvk: true
@@ -22,6 +23,7 @@ Executable:
   
 Steps:
 - action: install_exe
-  file_name: RSI-Setup-1.5.5.exe
-  url: https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.5.5.exe
-  file_checksum: 2ac76cd94eee754fdaa56f233d7bfcac
+  file_name: RSI-Setup-1.6.5.exe
+  arguments: /S
+  url: https://install.robertsspaceindustries.com/star-citizen/RSI-Setup-1.6.5.exe
+  file_checksum: acdc48032606bcf4e0913e15711b5fc2

--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -36,7 +36,7 @@ Steps:
     cat << EOF > "${SC_FIX_SCRIPT}"
     #!/bin/bash
     # Bottles StarCitizen-installer fixer script"
-    # block EAC module access via DNS inside bottle
+    # block EAC module access via DNS inside bottle, by default for LIVE instance. Run starcitizen_eac.sh PTU for the PTU instance.
     bash !bottle_drive/starcitizen_eac.sh
     # add sysctl settings
     pkexec bash !bottle_drive/starcitizen_sysctl.sh
@@ -49,10 +49,18 @@ Steps:
     #!/bin/bash
     echo "127.0.0.1 modules-cdn.eac-prod.on.epicgames.com #block EAC access" >> !bottle_drive/windows/system32/drivers/etc/hosts
     cp "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json.backup"
+    if [[ "$1" == "PTU" ]]
+    then
+    sed -i "s#\"productid\":\(\s*\)\"\(.*\)\"#\"productid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/PTU/EasyAntiCheat/Settings.json"
+    sed -i "s#\"sandboxid\":\(\s*\)\"\(.*\)\"#\"sandboxid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/PTU/EasyAntiCheat/Settings.json"
+    sed -i "s#\"clientid\":\(\s*\)\"\(.*\)\"#\"clientid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/PTU/EasyAntiCheat/Settings.json"
+    sed -i "s#\"deploymentid\":\(\s*\)\"\(.*\)\"#\"deploymentid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/PTU/EasyAntiCheat/Settings.json"
+    else
     sed -i "s#\"productid\":\(\s*\)\"\(.*\)\"#\"productid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
     sed -i "s#\"sandboxid\":\(\s*\)\"\(.*\)\"#\"sandboxid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
     sed -i "s#\"clientid\":\(\s*\)\"\(.*\)\"#\"clientid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
     sed -i "s#\"deploymentid\":\(\s*\)\"\(.*\)\"#\"deploymentid\":\1\"\2NONONO\"#g" "${SC_DEFAULT_GAME_PATH}/LIVE/EasyAntiCheat/Settings.json"
+    fi
     EOF
 - action: run_script
   script: |

--- a/Reviews/starcitizen.md
+++ b/Reviews/starcitizen.md
@@ -32,4 +32,16 @@ Grade: Bronze
 Additional notes: n/a
 
 **Additional notes**  
-n/a
+SamPurple22@github
+
+After installing "RSI Installer", inside the prefix, the following folders need to be created manually, because the RSI Launcher fails to create them:
+"C:\Program Files\Roberts Space Industries\StarCitizen"
+"C:\Program Files\Roberts Space Industries\StarCitizen\LIVE"
+"C:\Program Files\Roberts Space Industries\StarCitizen\PTU"
+
+#inside /etc/hosts file, the following line needs to be added - WARNING - it will disable EAC for other games on the system, ex: The Division 2 via Ubisoft Connect.
+
+# /etc/hosts
+
+127.0.0.1 modules-cdn.eac-prod.on.epicgames.com #Star Citizen EAC workaround
+


### PR DESCRIPTION
Fixes #(issue)

## Type of change
- [ ] New installer
- [X] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [X] Yes
- [ ] No

Updated the manifest for the installer, fixed the following:

- Use the latest RSI installer version 1.6.5.
- Install just arial32 fonts, reduces some time to wait for the bottle installation process to finish (instead of all fonts).
- Install wine mono for .NET, avoids issue with dotnet45 getting stuck on install and also blocking the RSI Installer setup from finishing.
- Using /S for RSI-Setup-1.6.5.exe, means the installer will install silently and finish, with no auto launch, then it will need to be started from Bottle for first time.

Tested on Debian 12 (bookworm/testing) and Fedora 37 with flatpak Bottles 51.5.

Bugs left:
- **Folder create BUG:** RSI Launcher is not able to create the required folders by itself, so the folders need to be created manually before trying to install the game (either LIVE or PTU). This is a RSI Launcher issue. LUG Lutris installation script creates the folders manually when setting up the prefix, see the note in the Review file. If there would be a simple Bottles create_folder action then it would awesome to have this step integrated in the manifest (installer).
- **EAC workaround**: which is need to be able to log into the game. Not sure how Bottles should handle this just now, maybe just like LUG Helper, add the line from Review note into /etc/hosts. There are some other workarounds, still looking into this.
- **LUG helper** also adds this: sysctl -w vm.max_map_count=16777216 into a /etc/sysctl.d/lug-starcitizen.conf file.

I would like you to merge this, but we first need to at least fix the Folder create BUG somehow. Currently, it's not easy to add a new action to Bottles.

Would it also be possible maybe to present a INFO dialog/window to the user with the steps needed after this installer has been created?

