### PR TITLE
Update GOG Galaxy 2.0.67.2

### DIFF
--- a/Games/gog.yml
+++ b/Games/gog.yml
@@ -22,7 +22,7 @@ Executable:
   
 Steps:
 - action: install_exe
-  file_name: setup_galaxy_2.0.64.31.exe
-  url: https://content-system.gog.com/open_link/download?path=/open/galaxy/client/2.0.64.31/setup_galaxy_2.0.64.31.exe
-  file_checksum: a1aef5ddc47d1d246478700e44a9c19f
+  file_name: setup_galaxy_2.0.67.2.exe
+  url: https://content-system.gog.com/open_link/download?path=/open/galaxy/client/2.0.67.2/setup_galaxy_2.0.67.2.exe
+  file_checksum: b838eefedc1295a65c38a649a1ffa205
   arguments: /s

--- a/Games/gog.yml
+++ b/Games/gog.yml
@@ -4,7 +4,7 @@ Grade: Gold
 Arch: win64
 
 Dependencies:
-- vcredist2015
+- vcredist2019
 - allfonts
 
 Parameters:


### PR DESCRIPTION
* Update GOG Galaxy 2.0.67.2
* Update vcredist dependency from 2015 to 2019 for GOG Galaxy

I just noticed on the messages on the installer that Galaxy has updated their vcredist dependency to version 2019, so changing that too.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
