### PR TITLE
Fix FL Studio manifest

### DIFF
--- a/Software/flstudio.yml
+++ b/Software/flstudio.yml
@@ -10,7 +10,7 @@ Executable:
   name: FL Studio
   icon: flstudio.png
   file: FL64.exe
-  path: Program Files/Image-Line/FL Studio 20/FL64.exe
+  path: Program Files/Image-Line/FL Studio 21/FL64.exe
   arguments: ""
 
 Steps:

--- a/Software/flstudio.yml
+++ b/Software/flstudio.yml
@@ -15,7 +15,7 @@ Executable:
 
 Steps:
 - action: install_exe
-  file_name: flstudio_win64_21.0.3.3517.exe
-  url: https://demodownload.image-line.com/flstudio/flstudio_win64_21.0.3.3517.exe
-  file_checksum: 017018801046956f0ef758a897048140
+  file_name: flstudio_win64_21.1.1.3750.exe
+  url: https://demodownload.image-line.com/flstudio/flstudio_win64_21.1.1.3750.exe
+  file_checksum: 30e6727eaec87bd7276f2b7e1180e531
   arguments: ""


### PR DESCRIPTION
Fixes #192

- Updates the FL Studio download URL and installer checksum to version 21.1.1.
- Updates the FL Studio launcher path as it moved to `Program Files/Image-Line/FL Studio 21/**` with FL Studio 21 (fixes [FL Studio not launching](https://github.com/bottlesdevs/programs/issues/192#issuecomment-1380093375)).

## Type of change
- [ ] New installer
- [X] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [X] Yes
- [ ] No
