### PR TITLE
starcitizen.yml: Improve Launcher Performance with libglesv2 Override

### DIFF
--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -25,6 +25,7 @@ Executable:
     EOS_USE_ANTICHEATCLIENTNULL=1
     radv_zero_vram="true"
     WINE_HIDE_NVIDIA_GPU=1
+    WINEDLLOVERRIDES="libglesv2=builtin"
     %command%
 
 Steps:


### PR DESCRIPTION
This libglesv2 override seems to improve the performance of the RSI Launcher when interacting with certain components.

This is tested with the soda runner and also works with other runners well.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
