### PR TITLE
starcitizen.yml: Ensure that the installer works in custom bottles.

### DIFF
--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -6,6 +6,7 @@ Arch: win64
 Dependencies:
   - arial32
   - tahoma32
+  - mono
   - powershell
 
 Parameters:


### PR DESCRIPTION
It seems like wine mono is not included with the soda runner by default which causes the installer to hang when using a custom bottle.

Should be the last tiny tweak to this installer program :)

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
