### PR TITLE
Add KakaoTalk

### DIFF
--- a/Games/kakaotalk.yml
+++ b/Games/kakaotalk.yml
@@ -1,0 +1,38 @@
+Name: KakaoTalk
+Description: The official KakaoTalk desktop client.
+Grade: Silver
+Arch: win64
+
+Dependencies:
+- cjkfonts
+- mono
+
+Parameters:
+  discrete_gpu: true
+  
+Executable:
+  name: KakaoTalk
+  icon: kakaotalk.png
+  file: KakaoTalk.exe
+  path: Program Files (x86)/Kakao/KakaoTalk.exe
+  
+Steps:
+- action: install_exe
+  file_name: KakaoTalk_Setup.exe
+  url: https://app-pc.kakaocdn.net/talk/win32/KakaoTalk_Setup.exe
+  file_checksum: False
+  monitoring:
+    - KakaoTalk_Setup.exe
+  
+- action: set_windows
+    # Bump this if the system requirements change
+    # KakaoTalk offers multiple versions, including a version of the installer for outdated versions of Windows.
+    version: win10
+
+- action: update_config
+  path: userdir/AppData/Local/Kakao/KakaoTalk/prefs.ini
+  type: ini
+  # The font here is captured from user-installed fonts. A future change might be to download a compatible CJK font and install it.
+  upd_keys: 
+    KAKAO_TALK:
+      CustomFontFaceName: "Source Han Sans"


### PR DESCRIPTION
Add support for the instant messenger KakaoTalk.

## Type of change
- [x] New installer
- [ ] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x ] No

Running the installer is pretty easy, but you need to change the fonts in a menu to a CJK compatible font. For some reason on my machine, Bottles pulls from my `~/.local/share/fonts` folder. I deleted all my fonts and chose the font Source Sans Han, but this may need to be changed if it doesn't work on a fresh install.