### PR TITLE
hoyoplay: add webview2 dependency

### DIFF
--- a/Games/hoyoplay.yml
+++ b/Games/hoyoplay.yml
@@ -15,6 +15,7 @@ Dependencies:
 - d3dcompiler_43
 - d3dcompiler_47
 - d3dx9
+- webview2
 
 Parameters:
   dxvk: true


### PR DESCRIPTION
The absence of webview2 results in a black screen when launching HoYoPlay Launcher.

## Type of change
- [ ] New installer
- [X] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [X] Yes
- [ ] No
