### PR TITLE
battlenet: remove webview2

### DIFF
--- a/Games/battlenet.yml
+++ b/Games/battlenet.yml
@@ -9,7 +9,6 @@ Dependencies:
 - arial32
 - arialb32
 - vcredist2019
-- webview2
 
 Parameters:
   dxvk: true


### PR DESCRIPTION
Remove webview2 as it is unnecessary and installs MS Edge which generates background activity to keep it updated.
webview is not necessary to log into battlenet.


## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No
