### PR TITLE
Add --no-sandbox argument for Star Citizen

### DIFF
--- a/Games/starcitizen.yml
+++ b/Games/starcitizen.yml
@@ -26,7 +26,7 @@ Executable:
     radv_zero_vram="true"
     WINE_HIDE_NVIDIA_GPU=1
     WINEDLLOVERRIDES="libglesv2=builtin"
-    %command%
+    %command% --no-sandbox
 
 Steps:
   - action: set_windows


### PR DESCRIPTION
Without this argument RSI Launcher crashes on my system.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No

Crash log:
```
info:  Game: RSI Launcher.exe
info:  DXVK: v2.7.1
info:  Build: x86_64 gcc 15.1.0
info:  Vulkan: Found vkGetInstanceProcAddr in winevulkan.dll @ 0x6ffffd215810
info:  Extension providers:
info:    Platform WSI
info:    OpenVR
info:  OpenVR: could not open registry key, status 2
info:  OpenVR: Failed to locate module
info:    OpenXR
info:  Enabled instance extensions:
info:    VK_EXT_surface_maintenance1
info:    VK_KHR_get_surface_capabilities2
info:    VK_KHR_surface
info:    VK_KHR_win32_surface
ATTENTION: default value of option radv_zero_vram overridden by environment.
ATTENTION: default value of option radv_zero_vram overridden by environment.
WARNING: radv is not a conformant Vulkan implementation, testing use only.
WARNING: radv is not a conformant Vulkan implementation, testing use only.
info:  Found device: AMD Radeon RX 9070 XT (RADV GFX1201) (radv 25.2.6)
info:  Found device: AMD Radeon RX 9070 XT (RADV GFX1201) (radv 25.2.6)
01ec:err:ole:com_get_class_object class {7ab36653-1796-484b-bdfa-e74f1db7c1dc} not registered
01b4:err:combase:RoGetActivationFactory Failed to find library for L"Windows.Devices.Input.PenDevice"
01ec:err:ole:create_server class {7ab36653-1796-484b-bdfa-e74f1db7c1dc} not registered
01ec:err:ole:com_get_class_object no class object {7ab36653-1796-484b-bdfa-e74f1db7c1dc} could be created for context 0x5
0134:err:ole:com_get_class_object class {aa509086-5ca9-4c25-8f95-589d3c07b48a} not registered
0134:err:ole:com_get_class_object class {aa509086-5ca9-4c25-8f95-589d3c07b48a} not registered
0134:err:ole:create_server class {aa509086-5ca9-4c25-8f95-589d3c07b48a} not registered
0134:err:ole:com_get_class_object no class object {aa509086-5ca9-4c25-8f95-589d3c07b48a} could be created for context 0x17
[500:1218/160711.290:ERROR:net\base\network_change_notifier_win.cc:189] WSALookupServiceBegin failed with: 8
(node:304) [KOFFI003] DeprecationWarning: The koffi.cdecl() function was deprecated in Koffi 2.7, use koffi.func(...) instead
[304:1218/160711.370:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160711.485:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160711.614:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160711.726:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160711.839:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160711.953:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160712.066:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160712.179:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
16:07:12.198 > "[Analytics] Server accessible."
16:07:12.206 > "[Analytics] event sent successfully: App:Open (attempt 1)"
[304:1218/160712.289:ERROR:content\browser\gpu\gpu_process_host.cc:958] GPU process launch failed: error_code=43
[304:1218/160712.289:FATAL:content\browser\gpu\gpu_data_manager_impl_private.cc:415] GPU process isn't usable. Goodbye.
```

System:
```
❯ inxi -SG --no-host         
System:
  Kernel: 6.17.11-300.fc43.x86_64 arch: x86_64 bits: 64
  Desktop: GNOME v: 49.2 Distro: Fedora Linux 43.20251215.0 (Silverblue)
Graphics:
  Device-1: Advanced Micro Devices [AMD/ATI] Navi 48 [Radeon RX 9070/9070
    XT/9070 GRE] driver: amdgpu v: kernel
  Device-2: Logitech HD Pro Webcam C920 driver: snd-usb-audio,uvcvideo
    type: USB
  Display: wayland server: X.Org v: 24.1.9 with: Xwayland v: 24.1.9
    compositor: gnome-shell driver: dri: radeonsi gpu: amdgpu
    resolution: 2560x1440~180Hz
  API: OpenGL v: 4.6 vendor: amd mesa v: 25.2.7 renderer: AMD Radeon RX
    9070 XT (radeonsi gfx1201 LLVM 21.1.5 DRM 3.64 6.17.11-300.fc43.x86_64)
  API: Vulkan v: 1.4.328 drivers: radv,llvmpipe surfaces: N/A
  API: EGL Message: EGL data requires eglinfo. Check --recommends.
  Info: Tools: api: clinfo, glxinfo, vulkaninfo gpu: corectrl x11: xdriinfo,
    xdpyinfo, xprop, xrandr
```