### PR TITLE
fix: add .NET 10 for Roon

### DIFF
--- a/Software/roon.yml
+++ b/Software/roon.yml
@@ -5,6 +5,7 @@ Arch: win64
 
 Dependencies:
 - dotnetcoredesktop7
+- dotnetcoredesktop10
 
 Executable:
   name: Roon


### PR DESCRIPTION
Roon EA build 1643 marks the transition from .NET 7 to 10. Add it for the future stable client and current EA users.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
