### PR TITLE
misc: remove .NET 7 from Roon

### DIFF
--- a/Software/roon.yml
+++ b/Software/roon.yml
@@ -4,7 +4,6 @@ Grade: Gold
 Arch: win64
 
 Dependencies:
-- dotnetcoredesktop7
 - dotnetcoredesktop10
 
 Executable:


### PR DESCRIPTION
Roon now published updated that uses .NET 10 instead of .NET 7, modernizing the software and improving the performance. Remove unneeded .NET 7 from manifest.

## Type of change
- [ ] New installer
- [x] Manifest fix
- [ ] Other

# Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No (Not really needed, since it's just removing unused dependency.


